### PR TITLE
Add README.md for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Pax Construct
+
+http://team.ops4j.org/wiki/display/paxconstruct/Pax+Construct
+
+## Introduction
+
+Pax Construct provides a Swiss Army® knife for OSGi that helps you rapidly create, build, manage and
+deploy many types of OSGi bundles. The core functionality is provided by a flexible Maven2 plugin
+that enhances and streamlines the Maven build process for OSGi, along with intelligent archetypes
+that adapt according to your needs.
+
+Unix and Windows scripts are available to further reduce the need to remember (and type) long
+command strings. These scripts come with basic help text and can bootstrap themselves from an
+empty system.
+
+You can use Pax Construct to create a simple first bundle in less than a minute, all the way up to
+managing a Spring Dynamic Modules for OSGiTM system.
+
+## How to use
+
+See at: http://www.ops4j.org/projects/pax/construct/
+
+## How to develop
+
+### Prepare your environment
+
+Use [Apache Maven][maven] version 2.2.1 minimum. Version 3.x is recommended.
+
+[maven]: http://maven.apache.org "Apache Maven"
+
+### Build project
+
+Use this command to build project:
+
+    mvn clean install
+
+### Project resources
+
+* Issues management: http://team.ops4j.org/browse/PAXCONSTRUCT
+* Jenkins continuous integration build: http://ci.okidokiteam.com/hudson/job/org.ops4j.pax.construct
+* Ohloh report: https://www.ohloh.net/p/paxconstruct
+* Artifact deployment: http://repo1.maven.org/maven2/org/ops4j/pax/construct
+


### PR DESCRIPTION
I've update README.md for the project.

The link to hudson (jenkins) build is not accessible. I see that we have:
- http://ci.ops4j.org => not accessible
- from maven pom in project:

http://ci.okidokiteam.com/hudson/job/org.ops4j.pax.construct => not accessible.

Could you please make it clear what is the working link of continuous integration build for this project and I'll update the link accordingly.
